### PR TITLE
Feature/auto replication

### DIFF
--- a/app/models/concerns/uuid_format.rb
+++ b/app/models/concerns/uuid_format.rb
@@ -15,20 +15,22 @@ module UUIDFormat
         if uuid
           uuid = uuid.delete('-').downcase
         end
-        write_attribute(field.to_sym, uuid)
+        self[field.to_sym] = uuid
       end
 
       # Override the field's getter method.
       define_method("#{field}") do
-        _uuid = read_attribute(field.to_sym)
-        # 9th, 14th, 19th and 24th
-        if _uuid.include?("-") == false
-          _uuid.insert(8, "-")
-          _uuid.insert(13, "-")
-          _uuid.insert(18, "-")
-          _uuid.insert(23, "-")
+        uuid = self[field.to_sym]
+        if uuid && uuid.size == 32
+          unless uuid.include?("-")
+            uuid = uuid.dup # prevents changing the field on the object itself
+            uuid.insert(8, "-")   # 9th, 14th, 19th and 24th
+            uuid.insert(13, "-")
+            uuid.insert(18, "-")
+            uuid.insert(23, "-")
+          end
         end
-        _uuid
+        uuid
       end
 
       # Override the find_by_field(value) class method.
@@ -49,8 +51,8 @@ module UUIDFormat
 
       # Create validations
       validates field.to_sym, format: {
-          with: /\A[a-f0-9]{8}[a-f0-9]{4}[a-f0-9]{4}[a-f0-9]{4}[a-f0-9]{12}\Z/,
-          message: "must be a UUIDv4 without dashes to save to the db."
+          with: /\A[a-f0-9]{8}\-?[a-f0-9]{4}\-?[a-f0-9]{4}\-?[a-f0-9]{4}\-?[a-f0-9]{12}\Z/,
+          message: "Must be a UUIDv4."
         }, on: :save
 
 

--- a/spec/controllers/api_v1/replication_transfers_controller_spec.rb
+++ b/spec/controllers/api_v1/replication_transfers_controller_spec.rb
@@ -44,7 +44,7 @@ shared_examples "failure" do |id_field|
   end
   it "does not update the record" do
     put :update, post_body
-    instance_from_db = existing_instance.class.public_send("find_by_#{id_field}", existing_instance.public_send(id_field))
+    instance_from_db = existing_instance.class.public_send("find_by_#{id_field}!", existing_instance.public_send(id_field))
     expect(instance_from_db).to eql(existing_instance)
   end
 end
@@ -57,7 +57,7 @@ shared_examples "success" do |id_field, changed_fields|
   end
   it "updates the record" do
     put :update, post_body
-    instance_from_db = existing_instance.class.public_send("find_by_#{id_field}", existing_instance.public_send(id_field))
+    instance_from_db = existing_instance.class.public_send("find_by_#{id_field}!", existing_instance.public_send(id_field))
     changed_fields.each do |changed_field|
       expect(instance_from_db.public_send(changed_field)).to_not eql(existing_instance.public_send(changed_field))
     end
@@ -69,7 +69,7 @@ shared_examples "a statemachine" do |starting_status, allowed_statuses|
   context "starting_status==#{starting_status}" do
     before(:each) do
       status_hash = {
-          replication_status: ReplicationStatus.find_by_name(starting_status)
+          replication_status: ReplicationStatus.find_by_name!(starting_status)
       }
       @existing_instance = Fabricate("replication_transfer_#{starting_status}".to_sym, more_params)
     end

--- a/spec/fabricators/replication_transfer_fabricator.rb
+++ b/spec/fabricators/replication_transfer_fabricator.rb
@@ -5,7 +5,7 @@
 
 
 Fabricator(:replication_transfer) do
-  replication_id { Faker::Internet.password(7) }
+  replication_id { SecureRandom.uuid }
   bag { Fabricate(:bag) }
   from_node { Fabricate(:node) }
   to_node { Fabricate(:node) }

--- a/spec/models/replication_transfer_spec.rb
+++ b/spec/models/replication_transfer_spec.rb
@@ -11,10 +11,47 @@ describe ReplicationTransfer do
     expect(Fabricate(:replication_transfer)).to be_valid
   end
 
-  it "requires a replication_id" do
-    instance = Fabricate(:replication_transfer)
-    instance.replication_id = nil
-    expect(instance).to_not be_valid
+
+
+  context "update" do
+    it "requires a replication_id" do
+      record = Fabricate(:replication_transfer)
+      record.replication_id = nil
+      expect(record).to_not be_valid
+    end
   end
+
+  context "create" do
+    context "from_node != local_node" do
+      it "requires a replication_id" do
+        expect {
+          Fabricate(:replication_transfer, replication_id: nil)
+        }.to raise_error ActiveRecord::RecordInvalid
+      end
+      it "does not alter the replication_id" do
+        id = SecureRandom.uuid
+        record = Fabricate(:replication_transfer, replication_id: id)
+        expect(record.replication_id).to eql(id)
+      end
+    end
+
+    context "from_node==local_node" do
+      let(:record) {
+        Fabricate(:replication_transfer,
+                  replication_id: nil,
+                  from_node: Fabricate(:local_node, namespace: Rails.configuration.local_namespace))
+      }
+
+      it "does not require a replication_id" do
+        expect { record }.to_not raise_error
+      end
+      it "sets the replication_id to a uuid" do
+        expect(record.replication_id).to match /\A[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12}\Z/
+      end
+
+    end
+  end
+
+
 
 end


### PR DESCRIPTION
Cleanup uuid_format concern.
Fail-fast in repl tests.
Automatically set replication_id to a uuid if one is not provided on create.
