### PR TITLE
Replication api updates

### DIFF
--- a/app/models/replication_transfer.rb
+++ b/app/models/replication_transfer.rb
@@ -79,7 +79,7 @@ class ReplicationTransfer < ActiveRecord::Base
     # Allows for the state to be set if the fixity == false or bag_valid == false
     # TODO: What if a client sets the fixity to be an empty string?
     #       i.e. do we want to define empty as being equivalent to null
-    # TODO: Uhhhhh "received"? Find a way to use the enum and not a magic val
+    # TODO: Uhhhhh "received"? Use the enum and not a magic val
     if "received" == record.status # FIXITY_CHECK_STATES.include?(record.status) &&
        record.from_node.namespace == Rails.configuration.local_namespace
 

--- a/app/models/replication_transfer.rb
+++ b/app/models/replication_transfer.rb
@@ -80,7 +80,7 @@ class ReplicationTransfer < ActiveRecord::Base
     # TODO: What if a client sets the fixity to be an empty string?
     #       i.e. do we want to define empty as being equivalent to null
     # TODO: Uhhhhh "received"? Use the enum and not a magic val
-    if "received" == record.status # FIXITY_CHECK_STATES.include?(record.status) &&
+    if "received" == record.status && # FIXITY_CHECK_STATES.include?(record.status)
        record.from_node.namespace == Rails.configuration.local_namespace
 
       # logger.info "updating fixty_accept and state"

--- a/app/models/replication_transfer.rb
+++ b/app/models/replication_transfer.rb
@@ -137,9 +137,9 @@ class ReplicationTransfer < ActiveRecord::Base
   validates :bag_id, read_only: true, on: :update
   validates :fixity_alg_id, read_only: true, on: :update
   validates :fixity_nonce, read_only: true, on: :update
-  # validates :fixity_value, read_only: true, on: :update, unless: proc {|r| r.fixity_value_changed?(from: nil)}
-  # validates :fixity_accept, read_only: true, on: :update, unless: proc {|r| r.fixity_accept_changed?(from: nil)}
-  # validates :bag_valid, read_only: true, on: :update, unless: proc {|r| r.bag_valid_changed?(from: nil)}
+  validates :fixity_value, read_only: true, on: :update, unless: proc {|r| r.fixity_value_changed?(from: nil)}
+  validates :fixity_accept, read_only: true, on: :update, unless: proc {|r| r.fixity_accept_changed?(from: nil)}
+  validates :bag_valid, read_only: true, on: :update, unless: proc {|r| r.bag_valid_changed?(from: nil)}
   validates :protocol_id, read_only: true, on: :update
   validates :link, read_only: true, on: :update
 

--- a/spec/fabricators/bag_fabricator.rb
+++ b/spec/fabricators/bag_fabricator.rb
@@ -18,4 +18,5 @@ Fabricator(:bag) do
   created_at 1.second.ago
   updated_at 1.second.ago
   type "DataBag"
+  fixity_checks(count: 1) { Fabricate.build(:fixity_check, bag: nil) }
 end

--- a/spec/fabricators/fixity_check_fabricator.rb
+++ b/spec/fabricators/fixity_check_fabricator.rb
@@ -5,6 +5,7 @@
 
 
 Fabricator(:fixity_check) do
+  bag
   fixity_alg
   value { SecureRandom.uuid }
 end

--- a/spec/fabricators/replication_transfer_fabricator.rb
+++ b/spec/fabricators/replication_transfer_fabricator.rb
@@ -5,21 +5,23 @@
 
 
 Fabricator(:replication_transfer) do
-  replication_id { SecureRandom.uuid }
-  bag { Fabricate(:bag) }
-  from_node { Fabricate(:node) }
-  to_node { Fabricate(:node) }
-  status :requested
-  protocol { Fabricate(:protocol) }
-  link { Faker::Internet.url }
   bag_valid nil
-  fixity_alg { Fabricate(:fixity_alg) }
-  fixity_nonce { Faker::Internet.password(6) }
   fixity_value nil
   fixity_accept nil
   bag_man_request_id nil
+
+  status :requested
   created_at 1.second.ago
   updated_at 1.second.ago
+
+  bag { Fabricate(:bag) }
+  link { Faker::Internet.url }
+  to_node { Fabricate(:node) }
+  from_node { Fabricate(:node) }
+  protocol { Fabricate(:protocol) }
+  replication_id { SecureRandom.uuid }
+  fixity_alg { Fabricate(:fixity_alg) }
+  fixity_nonce { Faker::Internet.password(6) }
 end
 
 Fabricator(:replication_transfer_requested, from: :replication_transfer) do
@@ -29,6 +31,15 @@ end
 Fabricator(:replication_transfer_rejected, from: :replication_transfer) do
   status :rejected
   bag_man_request_id { Fabricate(:bag_man_request, status: :rejected).id }
+end
+
+Fabricator(:replication_transfer_received_nil, from: :replication_transfer) do
+  status :received
+
+  after_build { |replication_transfer, transients|
+    fixity_alg = bag.fixity_checks[0].fixity_alg
+    replication_transfer.update(fixity_alg: fixity_alg)
+  }
 end
 
 Fabricator(:replication_transfer_received, from: :replication_transfer) do


### PR DESCRIPTION
This adds piecemeal updates for fixity_value/bag_valid. It also has the server update the fixity_accept field and update the state if the fixity_value is correct.

A couple things we might want to go over before merging in the [replication transfer model](app/models/replication_transfer.rb):
- Verify the behavior is what we want when updating the state
  - i.e., if bag_valid is false, cancel the replication
- Check the fixity_value/fixity_accept/bag_valid validation
  - I had trouble previously when trying to save a replication if any of them were nil (the validations would reject it), so I had commented them out. The dirty validations look like they may be able to stay, as all three of the fields shouldn't be changed after they are initially set.
