### PR TITLE
Jobs style fixes

### DIFF
--- a/app/jobs/bag_man/bag_fixity_job.rb
+++ b/app/jobs/bag_man/bag_fixity_job.rb
@@ -4,17 +4,17 @@
 # See LICENSE.md for details.
 
 module BagMan
-
+  ##
+  # BagFixityJob calculates BagIt fixity using the SHA256 algorithm
+  # and updates a request.fixity field.
   class BagFixityJob < ActiveJob::Base
     queue_as :internal
 
     def perform(request, bag_location)
-      unless request.cancelled
-        bag = DPN::Bagit::Bag.new(bag_location)
-        request.fixity = bag.fixity(:sha256)
-        request.save!
-      end
+      return if request.cancelled
+      bag = DPN::Bagit::Bag.new(bag_location)
+      request.fixity = bag.fixity(:sha256)
+      request.save!
     end
   end
-
 end

--- a/app/jobs/bag_man/bag_preserve_job.rb
+++ b/app/jobs/bag_man/bag_preserve_job.rb
@@ -5,34 +5,31 @@
 
 require 'pairtree'
 
-
 module BagMan
-
+  ##
+  # BagPreserveJob transfers a retrieved BagIt bag into the storage location
   class BagPreserveJob < ActiveJob::Base
     queue_as :internal
 
     def perform(request, bag_location, storage_dir)
-      unless request.cancelled
-        bag = DPN::Bagit::Bag.new(bag_location)
-        pairtree = ::Pairtree.at(storage_dir, create: false)
-        pairtree = Pairtree.at(storage_dir, create: true)
-        ppath = pairtree.mk(bag.uuid)
-        perform_rsync(File.join(bag_location, "*"), ppath.path)
-        request.status = :preserved
-        request.preservation_location = ppath.path
-        request.save!
-      end
+      return if request.cancelled
+      bag = DPN::Bagit::Bag.new(bag_location)
+      pairtree = Pairtree.at(storage_dir, create: false)
+      pairtree ||= Pairtree.at(storage_dir, create: true)
+      ppath = pairtree.mk(bag.uuid)
+      perform_rsync(File.join(bag_location, "*"), ppath.path)
+      request.status = :preserved
+      request.preservation_location = ppath.path
+      request.save!
     end
 
     protected
+
     def perform_rsync(source_location, dest_location)
       options = ["-r -k --partial -q --copy-unsafe-links"]
       Rsync.run(source_location, dest_location, options) do |result|
-        if result.success? == false
-          raise RuntimeError, "Failed to transfer"
-        end
+        raise "Failed to transfer" unless result.success?
       end
     end
   end
-
 end

--- a/app/jobs/bag_man/bag_retrieval_job.rb
+++ b/app/jobs/bag_man/bag_retrieval_job.rb
@@ -4,31 +4,29 @@
 # See LICENSE.md for details.
 
 module BagMan
-
+  ##
+  # BagRetrievalJob uses rsync to retrieve a DPN bag from a remote node
   class BagRetrievalJob < ActiveJob::Base
     queue_as :internal
 
     def perform(request, staging_dir)
-      unless request.cancelled
-        destination = File.join staging_dir, request.id.to_s
-        FileUtils.mkdir_p(destination) unless File.exists? destination
-        perform_rsync(request.source_location, destination)
-        request.status = :downloaded
-        request.save!
-        saved_location = File.join destination, File.basename(request.source_location)
-        BagUnpackJob.perform_later(request, saved_location)
-      end
+      return if request.cancelled
+      destination = File.join staging_dir, request.id.to_s
+      FileUtils.mkdir_p(destination) unless File.exist? destination
+      perform_rsync(request.source_location, destination)
+      request.status = :downloaded
+      request.save!
+      saved_location = File.join destination, File.basename(request.source_location)
+      BagUnpackJob.perform_later(request, saved_location)
     end
 
     protected
+
     def perform_rsync(source_location, dest_location)
       options = ["-a --partial -q -k --copy-unsafe-links -e 'ssh -o PasswordAuthentication=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i #{Rails.configuration.transfer_private_key}' "]
       Rsync.run(source_location, dest_location, options) do |result|
-        if result.success? == false
-          raise RuntimeError, "Failed to transfer"
-        end
+        raise "Failed to transfer" unless result.success?
       end
     end
   end
-
 end

--- a/app/jobs/bag_man/bag_unpack_job.rb
+++ b/app/jobs/bag_man/bag_unpack_job.rb
@@ -4,34 +4,42 @@
 # See LICENSE.md for details.
 
 module BagMan
-
+  ##
+  # BagUnpackJob unpacks a DPN::BagIt::SerializedBag (.tar file);
+  # on success, it updates the request status to :unpacked and
+  # initiates bag validation and fixity calculation.
   class BagUnpackJob < ActiveJob::Base
     queue_as :internal
 
     def perform(request, bag_location)
-      unless request.cancelled
-        if File.directory?(bag_location) == false
-          case File.extname bag_location
-            when ".tar"
-              bag_location = unpack_tar(bag_location)
-            else
-              raise RuntimeError, "could not identify file type"
-          end
-        end
-        request.status = :unpacked
-        request.save!
-        BagValidateJob.perform_later(request, bag_location)
-        BagFixityJob.perform_later(request, bag_location)
+      return if request.cancelled
+      bag_location = unpack_bag(bag_location)
+      request.status = :unpacked
+      request.save!
+      BagMan::BagValidateJob.perform_later(request, bag_location)
+      BagMan::BagFixityJob.perform_later(request, bag_location)
+    end
+
+    protected
+
+    # @param path [String] bag location
+    # @return path [String] unpacked bag location
+    def unpack_bag(path)
+      return path if File.directory?(path)
+      case File.extname path
+      when ".tar"
+        unpack_tar(path)
+      else
+        raise "Could not unpack file type"
       end
     end
 
-
-    protected
+    # @param file [String] location of a serialized bag (.tar file)
+    # @return path [String] location of unpacked bag
     def unpack_tar(file)
       serialized_bag = DPN::Bagit::SerializedBag.new(file)
       bag = serialized_bag.unserialize!
-      return bag.location
+      bag.location
     end
   end
-
 end

--- a/app/jobs/bag_man/bag_validate_job.rb
+++ b/app/jobs/bag_man/bag_validate_job.rb
@@ -4,17 +4,17 @@
 # See LICENSE.md for details.
 
 module BagMan
-
+  ##
+  # BagValidateJob checks the validity for a DPN::BagIt::Bag
+  # and it updates the request validity field.
   class BagValidateJob < ActiveJob::Base
     queue_as :internal
 
     def perform(request, bag_location)
-      unless request.cancelled
-        bag = DPN::Bagit::Bag.new(bag_location)
-        request.validity = bag.valid?
-        request.save!
-      end
+      return if request.cancelled
+      bag = DPN::Bagit::Bag.new(bag_location)
+      request.validity = bag.valid?
+      request.save!
     end
   end
-
 end

--- a/spec/jobs/bag_man/bag_unpack_job_spec.rb
+++ b/spec/jobs/bag_man/bag_unpack_job_spec.rb
@@ -3,7 +3,6 @@
 # Licensed according to the terms of the Revised BSD License
 # See LICENSE.md for details.
 
-
 require 'rails_helper'
 
 describe BagMan::BagUnpackJob, type: :job do
@@ -32,14 +31,14 @@ describe BagMan::BagUnpackJob, type: :job do
     context "extension=#{file_type}" do
       before(:each) { allow(File).to receive(:extname).and_return(file_type) }
 
-      [true,false].each do |is_a_directory|
+      [true, false].each do |is_a_directory|
         context "File.directory? == #{is_a_directory}" do
           before(:each) { allow(File).to receive(:directory?).and_return(is_a_directory) }
 
           %w(BagValidateJob BagFixityJob).each do |spawned_job|
             let(:spawned_job_class) { "BagMan::#{spawned_job}".constantize }
             it "enqueues a #{spawned_job}" do
-              expect {subject}.to enqueue_a(spawned_job_class)
+              expect { subject }.to enqueue_a(spawned_job_class)
             end
 
             it "passes the request to the #{spawned_job}" do
@@ -48,7 +47,7 @@ describe BagMan::BagUnpackJob, type: :job do
             end
 
             it "passes the bag_location to the #{spawned_job}" do
-              expect(spawned_job_class).to receive(:perform_later).with(anything(), is_a_directory ? @bag_location : @unpacked_location)
+              expect(spawned_job_class).to receive(:perform_later).with(anything, is_a_directory ? @bag_location : @unpacked_location)
               subject
             end
           end
@@ -61,7 +60,4 @@ describe BagMan::BagUnpackJob, type: :job do
       end
     end
   end
-
-
-
 end


### PR DESCRIPTION
Reviewed code in `app/jobs/bag_man` and corrected some style recommendations.

The `pairtree` assignment change in `BagPreserveJob` is a concern, because there are no specs for this job.  Adding specs and testing the behavior of this job can be done in a new PR.
