### PR TITLE
Update secrets.yml.example

### DIFF
--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -15,6 +15,17 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+impersonate:
+  secret_key_base: 6e43de7f4a199ef787adc5757fd8dcd4bdf9a43d1b176a2840a86df9669460ed048e8d1c93c978e4aedff6806945ac96b2465567e4e7f7e54ae43625743e2f1c
+
+  # Load a salt in what is probably not a good place for it.
+  salt: "impersonate_salt"
+
+  # Set the cipher key, iv used to *crypt the auth_tokens other nodes
+  # identify us by.
+  cipher_key: some_cipher_key
+  cipher_iv: some_cipher_iv
+
 development:
   secret_key_base: 2ea1fbd4ac4699fd0e31096b51ef545b482d9ad4bd40ca7a07276a6712e45dccb821a88bc2adc09793b0ddc2be19e16068c48286ab659aad7807a8e5c1b32c3a
 


### PR DESCRIPTION
Adding this `impersonate` secrets enables the `script/setup_cluster.rb` to run and the Devise initializer to get a secret key.  (It doesn't seem to pickup the secret key base from `config/impersonate.yml`).  Without this, I get the following errors from that script:

```
Setting up db that impersonates local tdr node.
rake aborted!
Devise.secret_key was not set. Please add the following to your Devise initializer:

  config.secret_key = 'daccfca211cd817d81792ad6998b859b0f2c6838c39de6fb0091aee4fd169c776613eb32e49a9d93d91d3c588d382be04f9b319a748abc57cda6adfe67f483ed'

Please ensure you restarted your application after installing Devise or setting the key.
/data/src/dlss/dpn/dpn-server/.bundle/ruby/2.2.0/gems/devise-3.5.10/lib/devise/rails/routes.rb:489:in `raise_no_secret_key'
/data/src/dlss/dpn/dpn-server/.bundle/ruby/2.2.0/gems/devise-3.5.10/lib/devise/rails/routes.rb:223:in `devise_for'
/data/src/dlss/dpn/dpn-server/config/routes.rb:13:in `block in <top (required)>'
```
