### PR TITLE
db:migrate tweaks that worked for SDR deployment

### DIFF
--- a/db/migrate/20160429211031_change_fixity_checks_to_digests.rb
+++ b/db/migrate/20160429211031_change_fixity_checks_to_digests.rb
@@ -5,44 +5,18 @@
 
 class ChangeFixityChecksToDigests < ActiveRecord::Migration
 
-  class Bag < ActiveRecord::Base
-  end
-
-  class FixityCheck < ActiveRecord::Base
-    belongs_to :bag
-  end
-
   def up
-    add_column :fixity_checks, :node_id, :integer
-    add_column :fixity_checks, :created_at, :datetime
-
-    FixityCheck.all.each do |fc|
-      fc.update!(node_id: fc.bag.admin_node_id)
-    end
-
-    change_column :fixity_checks, :node_id, :integer, null: false
-    change_column :fixity_checks, :created_at, :datetime, null: false
-
     # Foreign keys are not renamed when you rename the table.
     # We recreate this fk after renaming the table.
     remove_foreign_key :fixity_checks, :bags
-
     rename_table :fixity_checks, :message_digests
-
-    add_foreign_key :message_digests, :bags,
-      column: :bag_id,
-      on_delete: :cascade,
-      on_update: :cascade
-
-    add_foreign_key :message_digests, :nodes,
-      column: :node_id,
-      on_delete: :restrict,
-      on_update: :cascade
   end
 
   def down
     rename_table :message_digests, :fixity_checks
-    remove_column :fixity_checks, :node_id
-    remove_column :fixity_checks, :created_at
+    add_foreign_key :fixity_checks, :bags,
+      column: :bag_id,
+      on_delete: :cascade,
+      on_update: :cascade
   end
 end

--- a/db/migrate/20160429211032_add_bags_to_digests.rb
+++ b/db/migrate/20160429211032_add_bags_to_digests.rb
@@ -1,0 +1,15 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+class AddBagsToDigests < ActiveRecord::Migration
+  def change
+    # bag_id exists already
+    add_foreign_key :message_digests, :bags,
+      name: 'message_digests_bags_id_fk',
+      column: 'bag_id',
+      on_delete: :cascade,
+      on_update: :cascade
+  end
+end

--- a/db/migrate/20160429211033_add_nodes_to_message_digests.rb
+++ b/db/migrate/20160429211033_add_nodes_to_message_digests.rb
@@ -1,0 +1,33 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+class AddNodesToMessageDigests < ActiveRecord::Migration
+
+  class Bag < ActiveRecord::Base
+  end
+
+  class MessageDigest < ActiveRecord::Base
+    belongs_to :bag
+  end
+
+  def up
+    add_column :message_digests, :node_id, :integer
+
+    MessageDigest.all.each do |md|
+      md.update!(node_id: md.bag.admin_node_id)
+    end
+    
+    add_foreign_key :message_digests, :nodes,
+      name: 'message_digests_nodes_id_fk',
+      column: 'node_id',
+      on_delete: :restrict,
+      on_update: :cascade
+  end
+
+  def down
+    remove_foreign_key :message_digests, :nodes
+    remove_column :message_digests, :node_id
+  end
+end

--- a/db/migrate/20160429211034_add_timestamps_to_message_digests.rb
+++ b/db/migrate/20160429211034_add_timestamps_to_message_digests.rb
@@ -1,0 +1,26 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+class AddTimestampsToMessageDigests < ActiveRecord::Migration
+
+  class Bag < ActiveRecord::Base
+  end
+
+  class MessageDigest < ActiveRecord::Base
+    belongs_to :bag
+  end
+
+  def up
+    add_column :message_digests, :created_at, :datetime
+    MessageDigest.all.each do |md|
+      md.update!(created_at: md.bag.created_at)
+    end
+    change_column :message_digests, :created_at, :datetime, null: false
+  end
+
+  def down
+    remove_column :message_digests, :created_at
+  end
+end

--- a/db/migrate/20160510205152_create_table_fixity_checks.rb
+++ b/db/migrate/20160510205152_create_table_fixity_checks.rb
@@ -13,17 +13,7 @@ class CreateTableFixityChecks < ActiveRecord::Migration
       t.datetime :fixity_at, null: false
       t.datetime :created_at, null: false
     end
-    
-    add_index :fixity_checks, :fixity_check_id, unique: true
 
-    add_foreign_key :fixity_checks, :bags,
-      column: :bag_id,
-      on_delete: :cascade,
-      on_update: :cascade
-    
-    add_foreign_key :fixity_checks, :nodes,
-      column: :node_id,
-      on_delete: :restrict,
-      on_update: :cascade
+    add_index :fixity_checks, :fixity_check_id, unique: true
   end
 end

--- a/db/migrate/20160510205153_add_bags_to_fixity_checks.rb
+++ b/db/migrate/20160510205153_add_bags_to_fixity_checks.rb
@@ -1,0 +1,13 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+class AddBagsToFixityChecks < ActiveRecord::Migration
+  def change
+    add_foreign_key :fixity_checks, :bags,
+      name: 'fixity_checks_bags_id_fk',
+      on_delete: :cascade,
+      on_update: :cascade
+  end
+end

--- a/db/migrate/20160510205154_add_nodes_to_fixity_checks.rb
+++ b/db/migrate/20160510205154_add_nodes_to_fixity_checks.rb
@@ -1,0 +1,13 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+class AddNodesToFixityChecks < ActiveRecord::Migration
+  def change
+    add_foreign_key :fixity_checks, :nodes,
+      name: 'fixity_checks_nodes_id_fk',
+      on_delete: :restrict,
+      on_update: :cascade
+  end
+end


### PR DESCRIPTION
These two commits split up a couple of migrations into more atomic units.  This helped to resolve some deployment failures in the migrations on MySQL for `dpn-dev.stanford.edu`.  One significant change in these commits is the use of a custom name for the foreign key constraints, because our deployment platform was using the same FK identifier for the constraints and refusing to create the FK for fixity_checks on nodes.
