### PR TITLE
Add application semantic version with an /api-v2/version route

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ end
 
 gem 'rails', '~> 4.2'
 
+gem 'app_version_tasks' # application semantic version
+
 gem 'active_scheduler', '~>0.3.0'
 gem 'resque', '~>1.26.0'
 gem 'resque-pool', '~>0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    app_version_tasks (0.1.0)
+      git (~> 1.3)
     arel (6.0.3)
     ast (2.3.0)
     bagit (0.3.2)
@@ -91,6 +93,7 @@ GEM
     fabrication (2.15.2)
     faker (1.6.6)
       i18n (~> 0.5)
+    git (1.3.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     highline (1.5.2)
@@ -273,6 +276,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_scheduler (~> 0.3.0)
+  app_version_tasks
   bcrypt
   byebug
   cancan

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,13 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
-# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+# for example lib/tasks/capistrano.rake, and they will automatically
+# be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+# From https://github.com/sul-dlss/app_version_tasks
+# A default configuration works for this application.
+spec = Gem::Specification.find_by_name 'app_version_tasks'
+load "#{spec.gem_dir}/lib/tasks/app_version_tasks.rake"
+require 'app_version_tasks'

--- a/app/controllers/version_controller.rb
+++ b/app/controllers/version_controller.rb
@@ -1,0 +1,17 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+# Returns DPN::Server::Application::VERSION
+class VersionController < ApplicationController
+  include Authenticate
+
+  def show
+    versions = {
+      app_version: DPN::Server::Application::VERSION,
+      api_version: VERSION
+    }
+    render json: versions
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,23 +15,26 @@ Bundler.require(*Rails.groups)
 module DPN
   module Server
     class Application < Rails::Application
+      # Provide DPN::Server::Application::VERSION
+      require_relative 'version'
+
       # Settings in config/environments/* take precedence over those specified here.
       # Application configuration should go into files in config/initializers
       # -- all .rb files in that directory are automatically loaded.
-  
+
       # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
       # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
       # config.time_zone = 'Central Time (US & Canada)'
-  
+
       # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
       # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
       # config.i18n.default_locale = :de
 
       config.autoload_paths << "#{Rails.root}/lib"
-  
+
       # Do not swallow errors in after_commit/after_rollback callbacks.
       config.active_record.raise_in_transactional_callbacks = true
-  
+
 
       config.generators do |g|
         g.test_framework :rspec,
@@ -42,7 +45,7 @@ module DPN
           :controller_specs => true,
           :request_specs => true
       end
-  
+
     end
   end
 end

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -3,5 +3,5 @@
 # Licensed according to the terms of the Revised BSD License
 # See LICENSE.md for details.
 
-
+# API Version
 VERSION = "2"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,5 +36,7 @@ Rails.application.routes.draw do
 
     get   "/ingest",                      controller: :ingests, action: :index
     post  "/ingest",                      controller: :ingests, action: :create
+
+    get   "/version", controller: :version, action: :show
   end
 end

--- a/config/version.rb
+++ b/config/version.rb
@@ -1,0 +1,5 @@
+module DPN::Server
+  class Application
+    VERSION = '2.0.0'.freeze
+  end
+end

--- a/spec/controllers/version_controller_spec.rb
+++ b/spec/controllers/version_controller_spec.rb
@@ -1,0 +1,27 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+require 'rails_helper'
+
+describe VersionController do
+  describe 'GET #show' do
+    context 'without authentication' do
+      before(:each) { get :show }
+      it_behaves_like 'an unauthenticated request'
+    end
+    context 'with authentication' do
+      include_context 'with authentication'
+      before(:each) { get :show }
+      it 'returns application version' do
+        versions = JSON.parse(response.body)
+        expect(versions).to include 'app_version'
+      end
+      it 'returns API version' do
+        versions = JSON.parse(response.body)
+        expect(versions).to include 'api_version'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This provides rake tasks to manage the semantic version for the application and a new route to support returning the app-sem-ver and the API ver, e.g.

``` sh
$ curl -H 'Authorization: Token token=hathi_token' http://localhost:3000/api-v2/version
{"app_version":"2.0.0","api_version":"2"}
```

See also https://github.com/sul-dlss/app_version_tasks, esp
- https://github.com/sul-dlss/app_version_tasks#usage

This will fix #66 
