### PR TITLE
Add okcomputer app monitor at /status routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'kaminari'
 gem 'lograge'
 gem 'logstash-event'
 
+gem 'okcomputer' # app monitoring
+
 gem 'rpairtree'
 gem 'rsync', '~>1.0.9'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
+    okcomputer (1.11.1)
     orm_adapter (0.5.0)
     parser (2.3.1.2)
       ast (~> 2.2)
@@ -289,6 +290,7 @@ DEPENDENCIES
   kaminari
   lograge
   logstash-event
+  okcomputer
   pry
   pry-doc
   rails (~> 4.2)

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,5 @@
+OkComputer.mount_at = 'status' # mounts at /status
+OkComputer.check_in_parallel = true
+
+OkComputer::Registry.register 'resque_down', OkComputer::ResqueDownCheck.new
+OkComputer.make_optional %w(resque_down)


### PR DESCRIPTION
Enable application monitoring using https://github.com/sportngin/okcomputer/

For example,

``` sh
$ curl http://localhost:3000/status
default: PASSED Application is running (0s)

$ curl http://localhost:3000/status/all.json
# see JSON response below
```

``` json
{
    "default": {
        "message": "Application is running",
        "success": true,
        "time": 1.8420396372675896e-06
    },
    "database": {
        "message": "Schema version: 20160921185130",
        "success": true,
        "time": 0.0028471939731389284
    },
    "resque_down": {
        "message": "Resque is working",
        "success": true,
        "time": 0.0008101860294118524
    }
}
```
