### PR TITLE
Fix mysql migration by removing nullify foreign key then re-creating it as restrict

### DIFF
--- a/db/migrate/20160927230135_node_not_null_in_message_digest.rb
+++ b/db/migrate/20160927230135_node_not_null_in_message_digest.rb
@@ -1,12 +1,16 @@
 class NodeNotNullInMessageDigest < ActiveRecord::Migration
-  def up
+
+  def change
+    remove_foreign_key :message_digests, column: :node_id
+    add_foreign_key :message_digests, :nodes,
+      column: :node_id,
+      on_delete: :restrict,
+      on_update: :cascade
+
     MessageDigest.where(node_id: nil).all.each do |md|
       md.update!(node_id: md.bag.admin_node_id)
     end
     change_column :message_digests, :node_id, :integer, null: false
   end
 
-  def down
-    change_column :message_digests, :node_id, :integer, null: true
-  end
 end


### PR DESCRIPTION
Resolves #103 
- This fix leaves us in a good state going forward.
- Instances that have already successfully applied the previous version of this migration do not need to take any action.
- Instances that have not applied the previous version of this migration can apply this migration regardless of their previous state.
