### PR TITLE
Fix bug where ill-configured rsync-over-ssh connections would hang instead of fail

### DIFF
--- a/app/jobs/client/repl/bag_retrieval_job.rb
+++ b/app/jobs/client/repl/bag_retrieval_job.rb
@@ -20,8 +20,18 @@ module Client
 
       protected
 
+      SSH_OPTIONS = [
+        "-o BatchMode=yes",
+        "-o ConnectTimeout=3",
+        "-o ChallengeResponseAuthentication=no",
+        "-o PasswordAuthentication=no",
+        "-o UserKnownHostsFile=/dev/null",
+        "-o StrictHostKeyChecking=no",
+        "-i #{Rails.configuration.transfer_private_key}"
+      ]
+
       def perform_rsync(source_location, dest_location)
-        options = ["-a --partial -q -k --copy-unsafe-links -e 'ssh -o PasswordAuthentication=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i #{Rails.configuration.transfer_private_key}' "]
+        options = ["-a --partial -q -k --copy-unsafe-links -e 'ssh #{SSH_OPTIONS.join(" ")}' "]
         Rsync.run(source_location, dest_location, options) do |result|
           raise "Failed to transfer" unless result.success?
         end

--- a/app/jobs/client/repl/bag_retrieval_job.rb
+++ b/app/jobs/client/repl/bag_retrieval_job.rb
@@ -30,9 +30,12 @@ module Client
         "-i #{Rails.configuration.transfer_private_key}"
       ]
 
+      def rsync_options
+        @rsync_options ||= ["-a --partial -q -k --copy-unsafe-links -e 'ssh #{SSH_OPTIONS.join(" ")}' "]
+      end
+
       def perform_rsync(source_location, dest_location)
-        options = ["-a --partial -q -k --copy-unsafe-links -e 'ssh #{SSH_OPTIONS.join(" ")}' "]
-        Rsync.run(source_location, dest_location, options) do |result|
+        Rsync.run(source_location, dest_location, rsync_options) do |result|
           raise "Failed to transfer" unless result.success?
         end
       end


### PR DESCRIPTION
Adds
- BatchMode=yes - disables password querying
- ChallengeResponseAuthentication=no - disallows other interactive auth
- ConnectTimeout=3 - Timeout for the connection
