### PR TITLE
Build multiple databases in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,11 @@ before_script:
 
 script: bundle exec rspec --tag ~broken_in_ci
 
+script:
+  - if [[ $DB = 'sqlite' ]]; then bundle exec rspec --tag ~broken_in_sqlite; fi
+  - if [[ $DB = 'mysql' ]]; then bundle exec rspec; fi
+  - if [[ $DB = 'postgres' ]]; then bundle exec rspec; fi
+
 addons:
   code_climate:
     repo_token: ce328d44d99a09d03c1dac2198c731dc8bfd22374fefc1917ce528b25a06ec4e

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ before_install:
 
 install:
   - bundle install --jobs=3 --retry=3
+  - sqlite3 --version
+  - mysql --version
+  - psql --version
 
 before_script:
   - bundle exec rake config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,44 @@
 language: ruby
 rvm:
   - 2.3.1
+
 branches:
   only:
     - master
     - develop
-script: bundle exec rspec --tag ~broken_in_ci
+
+services:
+  - mysql
+  - postgresql
+
+env:
+  - DB=sqlite
+  - DB=mysql
+  - DB=postgres
+
+before_install:
+  - if [[ $DB = 'sqlite' ]]; then echo "gem 'sqlite3'" > Gemfile.local; fi
+  - if [[ $DB = 'mysql' ]]; then echo "gem 'mysql2'" > Gemfile.local; fi
+  - if [[ $DB = 'postgres' ]]; then echo "gem 'pg'" > Gemfile.local; fi
+
 install:
   - bundle install --jobs=3 --retry=3
-  - bundle exec sqlite3 --version
+
+before_script:
   - bundle exec rake config
+  - cp config/database.yml.travis-$DB config/database.yml
+  - if [[ $DB = 'sqlite' ]]; then bundle exec rake db:create; fi
+  - if [[ $DB = 'mysql' ]]; then mysql -e 'CREATE DATABASE dpn;'; fi
+  - if [[ $DB = 'postgres' ]]; then psql -c 'CREATE DATABASE dpn;' -U postgres; fi
+  - bundle exec rake db:migrate
+
+script: bundle exec rspec --tag ~broken_in_ci
+
 addons:
   code_climate:
     repo_token: ce328d44d99a09d03c1dac2198c731dc8bfd22374fefc1917ce528b25a06ec4e
+
 notifications:
   slack:
-    
     secure: >
       NPN5UAfze0ArE08cpxZlgZ0dN1s2FSeoKaJnf/zElBM+GrL4WDsGwUfgMc9yqIgc3aiDc1HHjzkNtqJynz2+bkMSBqtxzXteZ/Dz1hklXv6u2SCjuVCEyb+rzq488fN78gB5ohV9ovzAFuPm+T1b/vnXmSYBtJbnm8TRxgHHkM5x1gNE1FY+oZERByIiL+KSrG/k3pqFF1AtY3tt0hGDSMp1xhRblDdPUkq8FydApxUxI/dr5Aq8yN7QX4FWQvjm4Oka9+W16mIz7FiYo16r1BgSOWhsFEfub/PhTdD7AJyx3919xjvmrXZf5TVCYrxDmqPq4Ijgi9tgI2zxYyKyydB4U3yV+yGbM3zWFDHDKdX+iWdxkUl7iCZ3VXjvjpZj8WoFixQcOXwBq3HH5j9OEFZsgWhGa9cbvMvqfXKi23NCW1ybRVzbTO6GfjPi7GOByTKgBBf54wQPf4zD/GBehHrmGQV5ylWhPHlWYE5YmoKFrFczwbv9iUXIM+4ytMHYF+PcvLjVEPVOSLxw7F7d4ZE6hLpDKl9sXlZfoLpNYQNrlPBbFJEN/RBvUwX98Z2Ks+FEP2j28FSB3tnw4RsHCGrWmGeLL+K7UReASOXJY679sn9GlAtvNWO28MzFxAYOWxfSHNJO8jWtpBo7xxZrxw0RLr+vJlwsQFMwxXXLl7s=

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -13,7 +13,17 @@ module ViewHelper
   end
 
   def paged_bag_collection(collection, page_size)
-    paged_collection(collection, page_size).merge!( { total_size: collection.sum(:size) })
+    paged_collection(collection, page_size).merge!(
+      { total_size: to_size(collection.sum(:size)) }
+    )
+  end
+
+  def to_size(value)
+    if value.is_a? String
+      Integer(value.split('.').first)
+    else
+      Integer(value)
+    end
   end
 
 end

--- a/config/database.yml.travis-mysql
+++ b/config/database.yml.travis-mysql
@@ -1,0 +1,15 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+test: 
+  adapter: mysql2
+  encoding: utf8
+  pool: 5
+  timeout: 5000
+  reconnect: true
+  port: 3306
+  database: dpn
+  username: travis
+

--- a/config/database.yml.travis-postgres
+++ b/config/database.yml.travis-postgres
@@ -1,0 +1,9 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+test: 
+  adapter: postgresql
+  database: dpn
+

--- a/config/database.yml.travis-sqlite
+++ b/config/database.yml.travis-sqlite
@@ -1,0 +1,10 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+test: 
+  adapter: sqlite3
+  database: ":memory"
+  timeout: 500
+

--- a/spec/models/fixity_check_spec.rb
+++ b/spec/models/fixity_check_spec.rb
@@ -55,7 +55,7 @@ describe FixityCheck do
 
   it_behaves_like "it has temporal scopes for", :created_at
 
-  describe "scope latest_only", :broken_in_ci do
+  describe "scope latest_only", :broken_in_sqlite do
     before(:each) do
       @bag1, @bag2 = Fabricate.times(2, :bag)
       @node1, @node2 = Fabricate.times(2, :node)

--- a/spec/models/ingest_spec.rb
+++ b/spec/models/ingest_spec.rb
@@ -100,7 +100,7 @@ describe Ingest do
     end
   end
 
-  describe "scope latest_only", :broken_in_ci do
+  describe "scope latest_only", :broken_in_sqlite do
     before(:each) do
       @bag1 = Fabricate(:bag)
       @bag2 = Fabricate(:bag)


### PR DESCRIPTION
This pull request adds support for building sqlite, mysql, and postgres in travis.  

Three files were created to enable this: 
- config/database.yml.travis-mysql
- config/database.yml.travis-sqlite
- config/database.yml.travis-postgres

Additionally .travis.yml was extended to move the above files into place as well as setup the build matrix.

No changes to the ruby/rails code were involved.
