### PR TITLE
Minimum migration changes for api-v1 -> api-v2

### DIFF
--- a/db/migrate/20160222203129_refactor_replication_transfer.rb
+++ b/db/migrate/20160222203129_refactor_replication_transfer.rb
@@ -59,7 +59,7 @@ class RefactorReplicationTransfer < ActiveRecord::Migration
       add_column :replication_transfers, :status, :integer, null: false, default: 0
 
       ReplicationTransfer.where(cancelled: true)
-        .update_all(status: :cancelled)
+        .update_all(status: ReplicationTransfer.statuses[:cancelled])
 
       ReplicationTransfer.where(cancel_reason: 'fixity_reject')
         .update_all(fixity_accept: false)
@@ -68,16 +68,16 @@ class RefactorReplicationTransfer < ActiveRecord::Migration
         .update_all(bag_valid: false)
 
       ReplicationTransfer.where(cancel_reason: 'reject')
-        .update_all(status: :rejected)
+        .update_all(status: ReplicationTransfer.statuses[:rejected])
 
       ReplicationTransfer.where(store_requested: true, cancelled: false, stored: false)
-        .update_all(status: :confirmed, fixity_accept: true, bag_valid: true)
+        .update_all(status: ReplicationTransfer.statuses[:confirmed], fixity_accept: true, bag_valid: true)
 
       ReplicationTransfer.where(stored: true, cancelled: false)
-        .update_all(status: :stored, fixity_accept: true, bag_valid: true)
+        .update_all(status: ReplicationTransfer.statuses[:stored], fixity_accept: true, bag_valid: true)
 
       ReplicationTransfer.where(fixity_value: nil, cancelled: false)
-        .update_all(status: :requested)
+        .update_all(status: ReplicationTransfer.statuses[:requested])
 
       remove_column :replication_transfers, :store_requested
       remove_column :replication_transfers, :stored

--- a/db/migrate/20160429211034_add_timestamps_to_message_digests.rb
+++ b/db/migrate/20160429211034_add_timestamps_to_message_digests.rb
@@ -13,7 +13,7 @@ class AddTimestampsToMessageDigests < ActiveRecord::Migration
   end
 
   def up
-    add_column :message_digests, :created_at, :datetime
+    add_column :message_digests, :created_at, :datetime, default: Time.at(1).utc
     MessageDigest.all.each do |md|
       md.update!(created_at: md.bag.created_at)
     end

--- a/db/migrate/20160803214414_delete_table_delayed_jobs.rb
+++ b/db/migrate/20160803214414_delete_table_delayed_jobs.rb
@@ -1,5 +1,22 @@
 class DeleteTableDelayedJobs < ActiveRecord::Migration
-  def change
+  def up
     drop_table :delayed_jobs
   end
+
+  def down
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
 end

--- a/db/migrate/20160805220611_change_table_restore_transfers.rb
+++ b/db/migrate/20160805220611_change_table_restore_transfers.rb
@@ -1,7 +1,7 @@
 class ChangeTableRestoreTransfers < ActiveRecord::Migration
   def change
     change_column_null :restore_transfers, :restore_id, false
-    remove_column :restore_transfers, :status
+    remove_column :restore_transfers, :status, :integer, default: 0, null: false
     add_column :restore_transfers, :accepted,   :boolean, default: false, null: false
     add_column :restore_transfers, :finished,   :boolean, default: false, null: false
     add_column :restore_transfers, :cancelled,  :boolean, default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,11 +96,11 @@ ActiveRecord::Schema.define(version: 20160927230136) do
   add_index "members", ["member_id"], name: "index_members_on_member_id", unique: true
 
   create_table "message_digests", force: :cascade do |t|
-    t.integer  "bag_id",        null: false
-    t.integer  "fixity_alg_id", null: false
-    t.text     "value",         null: false
-    t.integer  "node_id",       null: false
-    t.datetime "created_at",    null: false
+    t.integer  "bag_id",                                        null: false
+    t.integer  "fixity_alg_id",                                 null: false
+    t.text     "value",                                         null: false
+    t.integer  "node_id",                                       null: false
+    t.datetime "created_at",    default: '1970-01-01 00:00:01', null: false
   end
 
   add_index "message_digests", ["bag_id", "fixity_alg_id"], name: "index_message_digests_on_bag_id_and_fixity_alg_id", unique: true


### PR DESCRIPTION
### Goal

Aims to be a minimal version of #119.  
### Differences
- Fixes replication transfer rollback.
- Does NOT add a guard clause to prevent removing a foreign key that does not exist in the change_fixity_checks_to_digests migration.  Reasoning below.
- Does NOT separate the setting of the NOT NULL clause on message_digests.created_at into a separate migration.
- Adds full rollback definition for the delete_table_delayed_jobs migration.
- Adds slightly more rollback information for the change_table_restore_transfers migration.
### I like #119 more.  What do I need from this?
- Add this PR's fix to replication transfer rollback (6bce8f71cd6af72ae19ef7890a8e782e1cf144d3)
- Add this PR's support for rolling back the delayed job table's deletion (0608f1633d114b3cd84fcb650a865317aef7d17f)
- Remove #119's missing FK workaround (d5e4ec7305776e2d99becbaec068cd63314acf87)
### Problem with the workaround

Regarding 9ffde36c02377488a7ada1d2542fe0acab792edb " Fix migration: 20160429211031_change_fixity_checks_to_digests"
This fix only addresses a symptom of the underlying problem.  Evidently:

$ grep -i foreign mysqldump-dpn-prod-tdr-20161017.sql | grep -v FOREIGN_KEY_CHECKS | wc -l
0
This tells us the tdr database was not correctly deployed; likely it was based off the sqlite db/schema.rb which does not contain any foreign key commands.  The fix is to add the missing foreign keys to the deployed code.  If we make the change in the commit we end up hiding the underlying issue until the next time we edit a foreign key they don't have; plus the referential integrity will still be missing.
