### PR TITLE
Utility scripts to run specs locally for MySQL and Postgres

### DIFF
--- a/script/mysql_init.sql
+++ b/script/mysql_init.sql
@@ -1,0 +1,17 @@
+
+DROP DATABASE IF EXISTS dpn_test;
+CREATE DATABASE dpn_test
+    DEFAULT CHARACTER SET utf8
+    DEFAULT COLLATE utf8_general_ci;
+
+DROP DATABASE IF EXISTS dpn_development;
+CREATE DATABASE dpn_development
+    DEFAULT CHARACTER SET utf8
+    DEFAULT COLLATE utf8_general_ci;
+
+# DROP USER 'dpnAdmin'@'localhost';
+# CREATE USER 'dpnAdmin'@'localhost' IDENTIFIED BY 'dpnPass';
+GRANT ALL PRIVILEGES ON dpn_test.*
+  TO 'dpnAdmin'@'localhost' IDENTIFIED BY 'dpnPass';
+GRANT ALL PRIVILEGES ON dpn_development.*
+  TO 'dpnAdmin'@'localhost' IDENTIFIED BY 'dpnPass';

--- a/script/mysql_init_cluster.sql
+++ b/script/mysql_init_cluster.sql
@@ -1,0 +1,35 @@
+
+DROP DATABASE IF EXISTS dpn_cluster_aptrust;
+CREATE DATABASE dpn_cluster_aptrust
+    DEFAULT CHARACTER SET utf8
+    DEFAULT COLLATE utf8_general_ci;
+GRANT ALL PRIVILEGES ON dpn_cluster_aptrust.*
+  TO 'dpnAdmin'@'localhost' IDENTIFIED BY 'dpnPass';
+
+DROP DATABASE IF EXISTS dpn_cluster_chron;
+CREATE DATABASE dpn_cluster_chron
+    DEFAULT CHARACTER SET utf8
+    DEFAULT COLLATE utf8_general_ci;
+GRANT ALL PRIVILEGES ON dpn_cluster_chron.*
+  TO 'dpnAdmin'@'localhost' IDENTIFIED BY 'dpnPass';
+
+DROP DATABASE IF EXISTS dpn_cluster_hathi;
+CREATE DATABASE dpn_cluster_hathi
+    DEFAULT CHARACTER SET utf8
+    DEFAULT COLLATE utf8_general_ci;
+GRANT ALL PRIVILEGES ON dpn_cluster_hathi.*
+  TO 'dpnAdmin'@'localhost' IDENTIFIED BY 'dpnPass';
+
+DROP DATABASE IF EXISTS dpn_cluster_sdr;
+CREATE DATABASE dpn_cluster_sdr
+    DEFAULT CHARACTER SET utf8
+    DEFAULT COLLATE utf8_general_ci;
+GRANT ALL PRIVILEGES ON dpn_cluster_sdr.*
+  TO 'dpnAdmin'@'localhost' IDENTIFIED BY 'dpnPass';
+
+DROP DATABASE IF EXISTS dpn_cluster_tdr;
+CREATE DATABASE dpn_cluster_tdr
+    DEFAULT CHARACTER SET utf8
+    DEFAULT COLLATE utf8_general_ci;
+GRANT ALL PRIVILEGES ON dpn_cluster_tdr.*
+  TO 'dpnAdmin'@'localhost' IDENTIFIED BY 'dpnPass';

--- a/script/mysql_specs.sh
+++ b/script/mysql_specs.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+path=$(basename $(pwd))
+[[ $path != 'dpn-server' ]] && echo 'Must run from "dpn-server" path' && exit
+
+echo
+echo "To initialize MySQL db and user, you must have root user access and run:"
+echo "mysql -u root -p < ./db/mysql_init.sql"
+echo
+
+DB_DUMP_FILE=$1
+
+cat << EOF > Gemfile.local
+gem 'mysql2'
+EOF
+
+bundle install --quiet
+bundle exec rake config
+
+cat << EOF > config/database.yml
+test:
+  adapter: mysql2
+  encoding: utf8
+  pool: 5
+  timeout: 5000
+  reconnect: true
+  port: 3306
+  username: dpnAdmin
+  password: dpnPass
+  database: dpn_test
+EOF
+
+export RAILS_ENV=test
+bundle exec rake db:drop
+bundle exec rake db:create
+if [ "$DB_DUMP_FILE" != "" ]; then
+    mysql -u dpnAdmin --password=dpnPass dpn_test < $DB_DUMP_FILE
+fi
+bundle exec rake db:migrate
+bundle exec rake # rspec
+
+echo
+echo "To cleanup the MySQL tests, run:"
+echo "./script/mysql_specs_cleanup.sh"
+echo

--- a/script/mysql_specs_cleanup.sh
+++ b/script/mysql_specs_cleanup.sh
@@ -1,0 +1,1 @@
+./test_cleanup.sh

--- a/script/postgres_init.sh
+++ b/script/postgres_init.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+echo 'SELECT rolname FROM pg_roles;' | psql | grep -q 'dpnAdmin'
+if [[ $? -ne 0 ]]; then
+  echo
+  echo "Creating postgres user 'dpnAdmin'"
+  echo "Enter 'dpnPass' as the password"
+  createuser dpnAdmin --createdb --login --pwprompt
+fi
+
+echo
+echo "Creating postgres databases for 'dpn_development' and 'dpn_test'"
+dropdb dpn_development
+dropdb dpn_test
+createdb -T template0 --owner=dpnAdmin dpn_development
+createdb -T template0 --owner=dpnAdmin dpn_test
+
+echo
+echo "Creating postgres databases for local DPN cluster"
+dropdb dpn_cluster_aptrust
+dropdb dpn_cluster_chron
+dropdb dpn_cluster_hathi
+dropdb dpn_cluster_sdr
+dropdb dpn_cluster_tdr
+
+createdb -T template0 --owner=dpnAdmin dpn_cluster_aptrust
+createdb -T template0 --owner=dpnAdmin dpn_cluster_chron
+createdb -T template0 --owner=dpnAdmin dpn_cluster_hathi
+createdb -T template0 --owner=dpnAdmin dpn_cluster_sdr
+createdb -T template0 --owner=dpnAdmin dpn_cluster_tdr
+
+echo
+echo "To test access for dpnAdmin to the dpn_development db,"
+echo "run this command and enter 'dpnPass' as the password:"
+echo "psql -U dpnAdmin -h localhost -d dpn_development"

--- a/script/postgres_specs.sh
+++ b/script/postgres_specs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+path=$(basename $(pwd))
+[[ $path != 'dpn-server' ]] && echo 'Must run from "dpn-server" path' && exit
+
+echo
+echo "To initialize Postgres user and dbs, you must have admin access to run:"
+echo "./script/postgres_init.sh"
+echo
+
+PGPASSWORD="dpnPass"
+
+DB_DUMP_FILE=$1
+
+cat << EOF > Gemfile.local
+gem 'pg'
+EOF
+
+bundle install --quiet
+bundle exec rake config
+
+cat << EOF > config/database.yml
+test:
+  adapter: postgresql
+  host: localhost
+  database: dpn_test
+  username: dpnAdmin
+  password: $PGPASSWORD
+EOF
+
+export RAILS_ENV=test
+bundle exec rake db:drop
+bundle exec rake db:create
+if [ "$DB_DUMP_FILE" != "" ]; then
+    psql -h localhost -U dpnAdmin -d dpn_test < $DB_DUMP_FILE
+fi
+bundle exec rake db:migrate
+bundle exec rake # rspec
+
+echo
+echo "To cleanup the Postgres tests, run:"
+echo "./script/postgres_specs_cleanup.sh"
+echo

--- a/script/postgres_specs_cleanup.sh
+++ b/script/postgres_specs_cleanup.sh
@@ -1,0 +1,1 @@
+./test_cleanup.sh

--- a/script/test_cleanup.sh
+++ b/script/test_cleanup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+path=$(basename $(pwd))
+[[ $path != 'dpn-server' ]] && echo 'Must run from "dpn-server" path' && exit
+
+rm -f Gemfile.local
+bundle install --quiet
+bundle exec rake config
+git checkout -- db/schema.rb


### PR DESCRIPTION
With these scripts, developers can run rspec on MySQL and Postgres, something like:

``` sh
# run specs on a clean MySQL
./script/mysql_specs.sh
# run specs on a MySQL dump
./script/mysql_specs.sh mysql_dump.sql
```

``` sh
# run specs on a clean Postgres
./script/postgres_specs.sh
# run specs on a Postgres dump
./script/postgres_specs.sh postgres_dump.sql
```

Together with the travis.ci build matrix, this PR will fix #52.
