### PR TITLE
Fix latest only scope

### DIFF
--- a/spec/models/fixity_check_spec.rb
+++ b/spec/models/fixity_check_spec.rb
@@ -55,7 +55,7 @@ describe FixityCheck do
 
   it_behaves_like "it has temporal scopes for", :created_at
 
-  describe "scope latest_only", :broken_in_sqlite do
+  describe "scope latest_only" do
     before(:each) do
       @bag1, @bag2 = Fabricate.times(2, :bag)
       @node1, @node2 = Fabricate.times(2, :node)

--- a/spec/models/ingest_spec.rb
+++ b/spec/models/ingest_spec.rb
@@ -100,7 +100,7 @@ describe Ingest do
     end
   end
 
-  describe "scope latest_only", :broken_in_sqlite do
+  describe "scope latest_only" do
     before(:each) do
       @bag1 = Fabricate(:bag)
       @bag2 = Fabricate(:bag)


### PR DESCRIPTION
The latest_only scope for Ingest and FixityCheck was previously taking advantage of non-SQL compliant behavior of sqlite and mysql.  This PR changes those two scopes to not rely on that behavior, and should thus work in all database backends.

Unfortunately, ActiveRecord has little to no support for subqueries, so the AR query involves a fair bit of manual SQL.  
