### PR TITLE
Add the application semantic version to the OkComputer status details

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
 services:
   - mysql
   - postgresql
+  - redis
 
 env:
   - DB=sqlite

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -3,3 +3,11 @@ OkComputer.check_in_parallel = true
 
 OkComputer::Registry.register 'resque_down', OkComputer::ResqueDownCheck.new
 OkComputer.make_optional %w(resque_down)
+
+# Simply report the application semantic version
+class AppVersionCheck < OkComputer::Check
+  def check
+    mark_message "dpn-server: #{DPN::Server::Application::VERSION}"
+  end
+end
+OkComputer::Registry.register 'app_version', AppVersionCheck.new

--- a/spec/integration/okcomputer_status_spec.rb
+++ b/spec/integration/okcomputer_status_spec.rb
@@ -1,0 +1,18 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+require 'rails_helper'
+
+describe 'OkComputerStatus' do
+  describe 'GET /status' do
+    it 'returns application version' do
+      get '/status/all.json'
+      status_response = JSON.parse(response.body)
+      expect(status_response.keys).to include 'app_version'
+      message = status_response['app_version']['message']
+      expect(message).to include DPN::Server::Application::VERSION
+    end
+  end
+end


### PR DESCRIPTION
Fix https://github.com/dpn-admin/dpn-server/issues/129

For @sul-dlss monitoring systems, it can be useful to know what version of the application is running.  This data will also be useful for checking what other nodes in the DPN network are running - it can help to identify whether all the DPN nodes are running the same application version or not.
