### PR TITLE
Remove uniqueness validations on pseudo-primary keys (e.g. member_id)

### DIFF
--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -62,7 +62,7 @@ class Bag < ActiveRecord::Base
   validates :version_family_id, read_only: true, on: :update
 
   ### Static Validations
-  validates :uuid, presence: true, uniqueness: true,
+  validates :uuid, presence: true,
             format: { with: /\A[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i,
             message: "must be a valid v4 uuid." }
 

--- a/app/models/fixity_check.rb
+++ b/app/models/fixity_check.rb
@@ -22,7 +22,7 @@ class FixityCheck < ActiveRecord::Base
   validates :created_at,      read_only: true, on: :update
 
   ### Static Validations
-  validates :fixity_check_id, presence: true, uniqueness: true,
+  validates :fixity_check_id, presence: true,
     format: { with: /\A[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i,
       message: "must be a valid v4 uuid." }
   validates :bag,             presence: true

--- a/app/models/ingest.rb
+++ b/app/models/ingest.rb
@@ -24,7 +24,7 @@ class Ingest < ActiveRecord::Base
   validates :created_at,  read_only: true, on: :update
 
   ### Static Validations
-  validates :ingest_id, presence: true, uniqueness: true,
+  validates :ingest_id, presence: true,
     format: { with: /\A[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i,
       message: "must be a valid v4 uuid." }
   validates :bag,             presence: true

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -20,7 +20,7 @@ class Member < ActiveRecord::Base
   validates :member_id, read_only: true, on: :update
 
   ### Static Validations
-  validates :member_id, presence: true, uniqueness: true,
+  validates :member_id, presence: true,
             format: { with: /\A[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i,
             message: "must be a valid v4 uuid." }
   validates :name, presence: true, uniqueness: true

--- a/app/models/message_digest.rb
+++ b/app/models/message_digest.rb
@@ -27,7 +27,6 @@ class MessageDigest < ActiveRecord::Base
   validates :value,       presence: true
   validates :node,        presence: true
   validates :created_at,  presence: true
-  validates_uniqueness_of :bag, scope: :fixity_alg
 
   ### Scopes
   scope :created_after, ->(time) { where("created_at > ?", time) unless time.blank? }

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -122,7 +122,7 @@ class Node < ActiveRecord::Base
 
 
   ### Static Validations
-  validates :namespace, presence: true, uniqueness: true
+  validates :namespace, presence: true
   validates :name, presence: true, length: { minimum: 1 }
   validates :private_auth_token, presence: true, uniqueness: true
   validates :api_root, presence: true, uniqueness: true

--- a/app/models/replication_transfer.rb
+++ b/app/models/replication_transfer.rb
@@ -48,7 +48,7 @@ class ReplicationTransfer < ActiveRecord::Base
 
 
   ### Static Validations
-  validates :replication_id, uniqueness: true, presence: true
+  validates :replication_id, presence: true
   validates :from_node, presence: true
   validates :to_node, presence: true
   validates :bag, presence: true

--- a/app/models/restore_transfer.rb
+++ b/app/models/restore_transfer.rb
@@ -36,7 +36,7 @@ class RestoreTransfer < ActiveRecord::Base
 
 
   ### Static Validations
-  validates :restore_id, uniqueness: true, presence: true
+  validates :restore_id, presence: true
   validates :from_node, presence: true
   validates :to_node, presence: true
   validates :bag, presence: true

--- a/app/models/run_time.rb
+++ b/app/models/run_time.rb
@@ -7,7 +7,7 @@
 class RunTime < ActiveRecord::Base
   after_initialize :defaults!
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true
   validates :last_success, presence: true
 
   def defaults!

--- a/app/models/version_family.rb
+++ b/app/models/version_family.rb
@@ -14,7 +14,7 @@ class VersionFamily < ActiveRecord::Base
   
   has_many :bags, :inverse_of => :version_family
 
-  validates :uuid, presence: true, uniqueness: true,
+  validates :uuid, presence: true,
     format: { with: /\A[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i,
       message: "must be a valid v4 uuid." }
 

--- a/spec/models/fixity_check_spec.rb
+++ b/spec/models/fixity_check_spec.rb
@@ -38,7 +38,9 @@ describe FixityCheck do
   describe "fixity_check_id" do
     it "is unique" do
       r = Fabricate(:fixity_check)
-      expect(Fabricate.build(:fixity_check, fixity_check_id: r.fixity_check_id)).to_not be_valid
+      expect {
+        Fabricate(:fixity_check, fixity_check_id: r.fixity_check_id)
+      }.to raise_error ActiveRecord::RecordNotUnique
     end
     it "is a uuidv4" do
       expect(Fabricate.build(:fixity_check, fixity_check_id: SecureRandom.uuid)).to be_valid

--- a/spec/models/message_digest_spec.rb
+++ b/spec/models/message_digest_spec.rb
@@ -40,7 +40,9 @@ describe MessageDigest do
 
   it "is unique by fixity_alg-bag pairs" do
     r = Fabricate(:message_digest)
-    expect(Fabricate.build(:message_digest, fixity_alg: r.fixity_alg, bag: r.bag )).to_not be_valid
+    expect {
+      Fabricate(:message_digest, fixity_alg: r.fixity_alg, bag: r.bag )
+    }.to raise_error ActiveRecord::RecordNotUnique
   end
 
   it_behaves_like "it has temporal scopes for", :created_at

--- a/spec/models/run_time_spec.rb
+++ b/spec/models/run_time_spec.rb
@@ -19,7 +19,7 @@ describe RunTime do
     Fabricate(:run_time, name: "some_name")
     expect { 
       Fabricate(:run_time, name: "some_name")
-    }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name has already been taken")
+    }.to raise_error ActiveRecord::RecordNotUnique
   end
   
   it "populates last_success with epoch" do


### PR DESCRIPTION
This resolves #143 

Following this change, we now leave it up to the database to detect a duplicate record (by our distributed primary key).  The biggest consequence of this is one must now attempt to save (or check via SELECT first) in order to know the record is duplicate.  

A few tests were altered to check uniqueness by checking for for the RecordNotUnique exception.