### PR TITLE
Integration fixtures - replication_transfers - store_requested: true

### DIFF
--- a/test/fixtures/integration/aptrust/replication_transfers.yml
+++ b/test/fixtures/integration/aptrust/replication_transfers.yml
@@ -38,7 +38,7 @@ xfer01_to_sdr:
     to_node: sdr
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -52,6 +52,6 @@ xfer01_to_tdr:
     to_node: tdr
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false

--- a/test/fixtures/integration/chron/replication_transfers.yml
+++ b/test/fixtures/integration/chron/replication_transfers.yml
@@ -8,7 +8,7 @@ xfer01_to_hathi:
     to_node: hathi
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -22,7 +22,7 @@ xfer01_to_aptrust:
     to_node: aptrust
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -36,7 +36,7 @@ xfer01_to_sdr:
     to_node: sdr
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -50,6 +50,6 @@ xfer01_to_tdr:
     to_node: tdr
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false

--- a/test/fixtures/integration/hathi/replication_transfers.yml
+++ b/test/fixtures/integration/hathi/replication_transfers.yml
@@ -8,7 +8,7 @@ xfer01_to_aptrust:
     to_node: aptrust
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -22,7 +22,7 @@ xfer01_to_chron:
     to_node: chron
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -36,7 +36,7 @@ xfer01_to_sdr:
     to_node: sdr
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -50,6 +50,6 @@ xfer01_to_tdr:
     to_node: tdr
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false

--- a/test/fixtures/integration/sdr/replication_transfers.yml
+++ b/test/fixtures/integration/sdr/replication_transfers.yml
@@ -8,7 +8,7 @@ xfer01_to_hathi:
     to_node: hathi
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -22,7 +22,7 @@ xfer01_to_chron:
     to_node: chron
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -36,7 +36,7 @@ xfer01_to_aptrust:
     to_node: aptrust
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -50,7 +50,7 @@ xfer01_to_tdr:
     to_node: tdr
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 

--- a/test/fixtures/integration/tdr/replication_transfers.yml
+++ b/test/fixtures/integration/tdr/replication_transfers.yml
@@ -8,7 +8,7 @@ xfer01_to_hathi:
     to_node: hathi
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -22,7 +22,7 @@ xfer01_to_chron:
     to_node: chron
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -36,7 +36,7 @@ xfer01_to_sdr:
     to_node: sdr
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false
 
@@ -50,6 +50,6 @@ xfer01_to_aptrust:
     to_node: aptrust
     protocol: rsync
     fixity_alg: sha256
-    store_requested: false
+    store_requested: true
     stored: false
     cancelled: false


### PR DESCRIPTION
Most of the replication transfers have `store_requested: false`, which seems to defeat the purpose of a replication transfer - at least it trips up some integration tests on the dpn-sync project.  It's seem more likely that these values should be `store_requested: true`, no?