### PR TITLE
bundle update app_version_tasks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    app_version_tasks (0.1.0)
+    app_version_tasks (0.2.3)
       git (~> 1.3)
     arel (6.0.3)
     ast (2.3.0)


### PR DESCRIPTION
This new release of the app_version_tasks gem adds an option to push tags.  This update to the gem doesn't require any bump in the dpn-server version.