### PR TITLE
Replication Controller returns a 422

### DIFF
--- a/app/services/replication_transfer_updater.rb
+++ b/app/services/replication_transfer_updater.rb
@@ -134,7 +134,9 @@ class ReplicationTransferUpdater
     private
 
     def add_replicating_node
-      record.bag.replicating_nodes << record.to_node
+      unless record.bag.replicating_nodes.includes(record.to_node)
+        record.bag.replicating_nodes << record.to_node
+      end
     end
 
   end

--- a/app/services/replication_transfer_updater.rb
+++ b/app/services/replication_transfer_updater.rb
@@ -134,7 +134,7 @@ class ReplicationTransferUpdater
     private
 
     def add_replicating_node
-      unless record.bag.replicating_nodes.includes(record.to_node)
+      unless record.bag.replicating_nodes.include?(record.to_node)
         record.bag.replicating_nodes << record.to_node
       end
     end

--- a/spec/models/data_bag_spec.rb
+++ b/spec/models/data_bag_spec.rb
@@ -13,8 +13,8 @@ describe DataBag do
 
   it "has a factory that honors updated_at" do
     time = 1.year.ago
-    record = Fabricate(:data_bag, updated_at: 1.year.ago)
-    expect(record.updated_at.change(usec: 0)).to eql time.change(usec: 0)
+    record = Fabricate(:data_bag, updated_at: time)
+    expect(record.updated_at).to be_within(5.second).of(time)
   end
 
   describe "::find_fields" do


### PR DESCRIPTION
From #149, this adds a check to make sure we don't add a duplicate entry to a nodes `replicating_nodes` field. When doing so the uniq constraint on the db table for the (node_id, bag_id) pair is violated, which causes rails to return a 422 Unprocessable Entity.

The only thing I can think of is if this is the best place for this or not. If the replicating_nodes field is not updated in any other location then I suppose it's fine, otherwise having it be in the bag model itself may be appropriate.