### PR TITLE
Added reset_cluster.rb script 

### DIFF
--- a/script/reset_cluster.rb
+++ b/script/reset_cluster.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+# reset_cluster.sh
+#
+# Resets the databases for a cluster of DPN nodes for integration testing.
+# ----------------------------------------------------------------------
+
+# Make sure we're running from the right directory
+unless File.exists? "config.ru"
+  puts "Run this script from the top-level Rails directory "
+  puts "for the dpn-server project. E.g. script/reset_cluster.sh"
+  exit
+end
+
+%w(aptrust chron hathi sdr tdr).each do |node|
+  puts "Dropping db that impersonates local #{node} node."
+  `RAILS_ENV=impersonate_#{node} DATABASE_URL=sqlite3:db/impersonate_#{node}.sqlite3 bundle exec rake db:drop`
+  puts "Migrating db that impersonates local #{node} node."
+  `RAILS_ENV=impersonate_#{node} DATABASE_URL=sqlite3:db/impersonate_#{node}.sqlite3 bundle exec rake db:setup`
+end
+
+puts "Now run script/run_cluster.sh to run the cluster"


### PR DESCRIPTION
This commit adds one new script to the script directory: reset_cluster.rb. That script does not affect the running application. It's used in integration testing to wipe out and rebuild the db/impersonate_<node>.sqlite3 databases.

This is necessary, because some APTrust integration tests that mark replication transfers as complete leave records in the replicating_nodes table. If those records are not deleted, dpn-server gives this error the next time integration tests run:

> ActiveRecord::RecordInvalid (Validation failed: Bag has already been taken):
> app/services/replication_transfer_updater.rb:126:in 'add_replicating_node' app/services/replication_transfer_updater.rb:118:in 'update'
> app/services/replication_transfer_updater.rb:10:in 'update'
> app/controllers/replication_transfers_controller.rb:62:in 'update'

Integration tests run properly and are repeatable when reset_cluster.rb is run before run_cluster.rb.