### PR TITLE
Fix typo in InternodeTesting.md

### DIFF
--- a/InternodeTesting.md
+++ b/InternodeTesting.md
@@ -10,7 +10,7 @@ that we can still sync our registries, replicate bags, etc.
 
 We already have a set of test data fixtures in the
 test/fixtures/integration directory. When you run a [local DPN
-cluster](Custer.md), the nodes in the cluster load data from those
+cluster](Cluster.md), the nodes in the cluster load data from those
 fixtures. The fixtures also include a set of six DPN bags in the form
 of tar files.
 


### PR DESCRIPTION
Why:

* The Cluster link was pointing to 'custer.md'

This change addresses the need by:

* Fix the typo to point to Cluster.md