### PR TITLE
Support APTrust integration tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 # Note: These are not in a group block because doing
 #       so breaks group block usage in Gemfile.local
-gem 'sqlite3', group: [:development, :test]
+gem 'sqlite3', group: [:development, :test, :impersonate_aptrust, :impersonate_chron, :impersonate_hathi, :impersonate_sdr, :impersonate_tdr]
 gem 'app_version_tasks', group: [:development, :test]
 gem 'byebug', group: [:development, :test]
 gem 'codeclimate-test-reporter', group: [:development, :test]

--- a/config/environments/integration.rb
+++ b/config/environments/integration.rb
@@ -1,0 +1,63 @@
+# Copyright (c) 2015 The Regents of the University of Michigan.
+# All Rights Reserved.
+# Licensed according to the terms of the Revised BSD License
+# See LICENSE.md for details.
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in
+  # config/application.rb.  Also, these settings will be supplemented by
+  # config/dpn.yml when it is loaded by config/initializers/dpn.rb
+
+  # In the development environment your application's code is reloaded on
+  # every request. This slows down response time but is perfect for development
+  # since you don't have to restart the web server when you make code changes.
+  config.cache_classes = false
+
+  # Do not eager load code on boot.
+  config.eager_load = false
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  # Don't care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = {
+    host: 'localhost',
+    port: 3000
+  }
+
+  # Print deprecation notices to the Rails logger.
+  config.active_support.deprecation = :log
+
+  # Raise an error on page load if there are pending migrations.
+  config.active_record.migration_error = :page_load
+
+  # Debug mode disables concatenation and preprocessing of assets.
+  # This option may cause significant delays in view rendering with a large
+  # number of complex assets.
+  config.assets.debug = true
+
+  # Asset digests allow you to set far-future HTTP expiration dates on all
+  # assets, yet still be able to expire them through the digest params.
+  config.assets.digest = true
+
+  # Adds additional error checking when serving assets at runtime.
+  # Checks for improperly declared sprockets dependencies.
+  # Raises helpful error messages.
+  config.assets.raise_runtime_errors = true
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
+
+  # Load a salt in what is probably not a good place for it.
+  config.salt = Rails.application.secrets.salt
+
+  # Set the cipher key used to *crypt the auth_tokens other nodes
+  # identify us by.
+  config.cipher_key = Rails.application.secrets.cipher_key
+  config.cipher_iv = Rails.application.secrets.cipher_iv
+
+  # The location of the private key used to pull files from other nodes
+  config.transfer_private_key = Rails.application.secrets.transfer_private_key
+end


### PR DESCRIPTION
Changes in this branch have no effect on the develop, test, or production environments. This branch simply adds a config file for an environment called integration, and it tells the Gemfile to load the sqlite DB adapter when running in any of the integration configurations. These changes support the integration tests that any nodes can run at will, and which APTrust runs often.